### PR TITLE
Switch to using main for development branch name in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
       - release-*
   pull_request: {}
   workflow_dispatch: {}
@@ -306,10 +306,10 @@ jobs:
           GIT_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Promote Artifacts in S3 and Docker Hub
-        if: github.ref == 'refs/heads/master' && env.AWS_USR != '' && env.DOCKER_USR != ''
+        if: github.ref == 'refs/heads/main' && env.AWS_USR != '' && env.DOCKER_USR != ''
         run: make -j2 promote
         env:
-          BRANCH_NAME: master
-          CHANNEL: master
+          BRANCH_NAME: main
+          CHANNEL: main
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_USR }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_PSW }}


### PR DESCRIPTION
Updates CI workflow to reflect that development branch in named main in
this repository.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>