### PR TITLE
Add conditions and print columns to access key

### DIFF
--- a/apis/accesskey/v1alpha1/types.go
+++ b/apis/accesskey/v1alpha1/types.go
@@ -81,9 +81,10 @@ type AccessKeyStatus struct {
 
 // An AccessKey is an SSH key with read or write access to a bitbucket git repo.
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="STATUS",type="string",JSONPath=".status.bindingPhase"
-// +kubebuilder:printcolumn:name="ID",type="string",JSONPath=".status.atProvider.id"
-// +kubebuilder:printcolumn:name="CLASS",type="string",JSONPath=".spec.classRef.name"
+// +kubebuilder:printcolumn:name="PROJECT",type="string",JSONPath=".spec.forProvider.projectKey"
+// +kubebuilder:printcolumn:name="REPO-NAME",type="string",JSONPath=".spec.forProvider.repoName"
+// +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
+// +kubebuilder:printcolumn:name="READY",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:scope=Cluster
 type AccessKey struct {

--- a/internal/controller/accesskey/accesskey.go
+++ b/internal/controller/accesskey/accesskey.go
@@ -161,6 +161,8 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 		return managed.ExternalObservation{}, errors.Wrap(err, errGetFailed)
 	}
 
+	cr.Status.SetConditions(xpv1.Available())
+
 	cr.Status.AtProvider.ID = key.ID
 	cr.Status.AtProvider.Key = &v1alpha1.PublicKey{
 		Key:        key.Key,

--- a/internal/controller/accesskey/accesskey_test.go
+++ b/internal/controller/accesskey/accesskey_test.go
@@ -134,7 +134,7 @@ func TestObserve(t *testing.T) {
 						Key:        key1,
 						Permission: bitbucket.PermissionRepoRead,
 					},
-				})),
+				}), withConditions(xpv1.Available())),
 				o: managed.ExternalObservation{
 					ResourceExists:    true,
 					ResourceUpToDate:  true,
@@ -167,7 +167,7 @@ func TestObserve(t *testing.T) {
 						Key:        key1,
 						Permission: bitbucket.PermissionRepoWrite,
 					},
-				})),
+				}), withConditions(xpv1.Available())),
 				o: managed.ExternalObservation{
 					ResourceExists:    true,
 					ResourceUpToDate:  false,

--- a/package/crds/accesskey.bitbucket-server.crossplane.io_accesskeys.yaml
+++ b/package/crds/accesskey.bitbucket-server.crossplane.io_accesskeys.yaml
@@ -15,14 +15,17 @@ spec:
   scope: Cluster
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .status.bindingPhase
-      name: STATUS
+    - jsonPath: .spec.forProvider.projectKey
+      name: PROJECT
       type: string
-    - jsonPath: .status.atProvider.id
-      name: ID
+    - jsonPath: .spec.forProvider.repoName
+      name: REPO-NAME
       type: string
-    - jsonPath: .spec.classRef.name
-      name: CLASS
+    - jsonPath: .status.conditions[?(@.type=='Synced')].status
+      name: SYNCED
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: READY
       type: string
     - jsonPath: .metadata.creationTimestamp
       name: AGE


### PR DESCRIPTION
This change will ensure that access keys reach ready condition for usage in compositions.
Also when printing accesskeys the status of the object along with which project and repo it relates to is printed.