### PR TITLE
switch key generation from rsa to ed25519

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/crossplane/crossplane-runtime v0.15.1
 	github.com/crossplane/crossplane-tools v0.0.0-20201201125637-9ddc70edfd0d
 	github.com/google/go-cmp v0.5.5
+	github.com/mikesmitty/edkey v0.0.0-20170222072505-3356ea4e686a
 	github.com/pkg/errors v0.9.1
 	golang.org/x/crypto v0.0.0-20210314154223-e6e6c4f2bb5b
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6

--- a/go.sum
+++ b/go.sum
@@ -371,6 +371,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
+github.com/mikesmitty/edkey v0.0.0-20170222072505-3356ea4e686a h1:eU8j/ClY2Ty3qdHnn0TyW3ivFoPC/0F1gQZz8yTxbbE=
+github.com/mikesmitty/edkey v0.0.0-20170222072505-3356ea4e686a/go.mod h1:v8eSC2SMp9/7FTKUncp7fH9IwPfw+ysMObcEz5FWheQ=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=

--- a/internal/controller/accesskey/accesskey.go
+++ b/internal/controller/accesskey/accesskey.go
@@ -21,11 +21,11 @@ import (
 	"context"
 	"crypto/ed25519"
 	"crypto/rand"
-	"crypto/x509"
 	"encoding/pem"
 	"fmt"
 	"strconv"
 
+	"github.com/mikesmitty/edkey"
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/ssh"
 	"k8s.io/apimachinery/pkg/types"
@@ -209,13 +209,10 @@ func keygen() (string, []byte, error) {
 	if err != nil {
 		return "", nil, err
 	}
-	privateBytes, err := x509.MarshalPKCS8PrivateKey(privateKey)
-	if err != nil {
-		return "", nil, err
-	}
+	privateBytes := edkey.MarshalED25519PrivateKey(privateKey)
 
 	// generate encoded private key pem
-	privateKeyPEM := &pem.Block{Type: "PRIVATE KEY", Bytes: privateBytes}
+	privateKeyPEM := &pem.Block{Type: "OPENSSH PRIVATE KEY", Bytes: privateBytes}
 	if err != nil {
 		return "", nil, err
 	}

--- a/internal/controller/accesskey/accesskey.go
+++ b/internal/controller/accesskey/accesskey.go
@@ -19,8 +19,8 @@ package accesskey
 import (
 	"bytes"
 	"context"
+	"crypto/ed25519"
 	"crypto/rand"
-	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
@@ -205,22 +205,32 @@ func (c *external) create(ctx context.Context, cr *v1alpha1.AccessKey) error {
 }
 
 func keygen() (string, []byte, error) {
-	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		return "", nil, err
 	}
-	privateKeyPEM := &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(privateKey)}
+	privateBytes, err := x509.MarshalPKCS8PrivateKey(privateKey)
+	if err != nil {
+		return "", nil, err
+	}
+
+	// generate encoded private key pem
+	privateKeyPEM := &pem.Block{Type: "PRIVATE KEY", Bytes: privateBytes}
+	if err != nil {
+		return "", nil, err
+	}
 	var private bytes.Buffer
 	if err := pem.Encode(&private, privateKeyPEM); err != nil {
 		return "", nil, err
 	}
-	// generate public key
-	pub, err := ssh.NewPublicKey(&privateKey.PublicKey)
+
+	// generate ssh authorized public key
+	sshPublicKey, err := ssh.NewPublicKey(publicKey)
 	if err != nil {
 		return "", nil, err
 	}
-	public := ssh.MarshalAuthorizedKey(pub)
-	return string(public), private.Bytes(), nil
+	authorizedKey := ssh.MarshalAuthorizedKey(sshPublicKey)
+	return string(authorizedKey), private.Bytes(), nil
 }
 
 func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.ExternalCreation, error) {


### PR DESCRIPTION
This will switch the generation of ssh-keys from RSA to ed25519.
Signed-off-by: Lars Haugan <lars.haugan@sparebank1.no>